### PR TITLE
ci: add Quality Gate workflow with Claude auto-fix loop

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,296 @@
+name: Quality Gate
+
+on:
+  pull_request:
+    branches: [master, main]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  actions: read
+
+concurrency:
+  group: quality-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Run Quality Gate
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    outputs:
+      passed: ${{ steps.gate.outputs.passed }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install bandit
+
+      - name: Run quality gate
+        id: gate
+        env:
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
+          TERRASAFE_API_KEY_HASH: "$2b$12$LJ3m9ZkRjWyEbhMxBqXvkuN/3QlGYbTEwHqMFEVBBxkLpN0uWxjAq"
+          TERRASAFE_ENVIRONMENT: development
+          TERRASAFE_DATABASE_URL: "postgresql+asyncpg://test:test@localhost:5432/test"
+          TERRASAFE_REDIS_URL: "redis://localhost:6379"
+          TERRASAFE_LOG_LEVEL: INFO
+          GATE_REPORT_PATH: gate-report.md
+        run: |
+          set +e
+          python scripts/quality_gate.py
+          rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit $rc
+
+      - name: Upload gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-gate-report
+          path: gate-report.md
+          retention-days: 14
+
+      - name: Comment on PR with failure report
+        if: failure() && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = fs.existsSync('gate-report.md')
+              ? fs.readFileSync('gate-report.md', 'utf8')
+              : '_Report file was not produced._';
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const hint = labels.includes('auto-fix')
+              ? '\n\n🤖 The `auto-fix` label is set — Claude will attempt a fix in this run.'
+              : '\n\n💡 Add the `auto-fix` label to let Claude attempt a fix automatically (max 3 attempts).';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Quality Gate failed\n\n${report}${hint}`,
+            });
+
+  auto-fix:
+    name: Claude Auto-Fix
+    needs: gate
+    if: |
+      always() &&
+      needs.gate.result == 'failure' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'auto-fix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Compute attempt counter
+        id: limits
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const prior = commits.filter(c =>
+              c.commit.message.startsWith('chore(quality-gate):')
+            );
+            const attempt = prior.length + 1;
+            const MAX = 3;
+            core.setOutput('attempt', String(attempt));
+            core.setOutput('max', String(MAX));
+            core.setOutput('proceed', String(attempt <= MAX));
+            if (attempt > MAX) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `🛑 Auto-fix attempt limit (${MAX}) reached. Please review the gate failures manually and remove the \`auto-fix\` label when ready to retry.`,
+              });
+            }
+
+      - name: Checkout PR branch (writable)
+        if: steps.limits.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_FIX_PAT || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+
+      - name: Set up Python
+        if: steps.limits.outputs.proceed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        if: steps.limits.outputs.proceed == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install bandit
+
+      - name: Download gate report
+        if: steps.limits.outputs.proceed == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: quality-gate-report
+          path: .
+
+      - name: Configure git identity for bot
+        if: steps.limits.outputs.proceed == 'true'
+        run: |
+          git config user.name  "claude-auto-fix[bot]"
+          git config user.email "claude-auto-fix[bot]@users.noreply.github.com"
+
+      - name: Run Claude auto-fix
+        if: steps.limits.outputs.proceed == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
+          TERRASAFE_API_KEY_HASH: "$2b$12$LJ3m9ZkRjWyEbhMxBqXvkuN/3QlGYbTEwHqMFEVBBxkLpN0uWxjAq"
+          TERRASAFE_ENVIRONMENT: development
+          TERRASAFE_DATABASE_URL: "postgresql+asyncpg://test:test@localhost:5432/test"
+          TERRASAFE_REDIS_URL: "redis://localhost:6379"
+          TERRASAFE_LOG_LEVEL: INFO
+          GATE_REPORT_PATH: gate-report.md
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          ATTEMPT: ${{ steps.limits.outputs.attempt }}
+          MAX_ATTEMPTS: ${{ steps.limits.outputs.max }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowed-tools "Bash,Read,Edit,Write,Grep,Glob"'
+          prompt: |
+            The TerraSafe Quality Gate failed on PR #${{ github.event.pull_request.number }}.
+            This is auto-fix attempt ${{ steps.limits.outputs.attempt }} of ${{ steps.limits.outputs.max }}.
+
+            Read `gate-report.md` at the repo root for the exact failures. The gate
+            enforces:
+              - pytest: every test passes
+              - coverage: line-rate >= 74.00 %
+              - pylint:  score == 10.00 / 10
+              - flake8:  0 findings
+              - bandit:  0 findings at -ll
+              - mypy:    0 errors
+
+            Your job, in order:
+              1. Diagnose each failed check from `gate-report.md`.
+              2. Apply the minimal change set that makes those checks pass without
+                 altering unrelated behavior.
+              3. Follow project conventions in `CLAUDE.md` and the per-layer guides
+                 under `terrasafe/*/CLAUDE.md`.
+              4. After editing, verify locally:
+                   `python scripts/quality_gate.py`
+                 Iterate until it exits 0, or until you are confident the remaining
+                 failure cannot be auto-fixed.
+              5. Stage and commit the changes:
+                   `git add -A`
+                   `git commit -m "chore(quality-gate): auto-fix attempt ${{ steps.limits.outputs.attempt }}"`
+              6. Push to the PR branch:
+                   `git push origin HEAD:${{ github.event.pull_request.head.ref }}`
+
+            Hard constraints:
+              - Do NOT add features, refactors, or abstractions beyond what the
+                failing checks require.
+              - Do NOT weaken thresholds: never edit `scripts/quality_gate.py`,
+                `.pylintrc`, `.bandit`, `mypy.ini`, `.coveragerc`, or
+                `.github/workflows/quality-gate.yml`.
+              - Do NOT silently skip or xfail tests to bypass failures. If a test
+                is genuinely broken upstream, document it in a PR comment.
+              - If a failure cannot be fixed safely, leave a PR comment explaining
+                why instead of making a misleading commit.
+
+      - name: Verify gate after auto-fix
+        if: steps.limits.outputs.proceed == 'true'
+        id: verify
+        env:
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
+          TERRASAFE_API_KEY_HASH: "$2b$12$LJ3m9ZkRjWyEbhMxBqXvkuN/3QlGYbTEwHqMFEVBBxkLpN0uWxjAq"
+          TERRASAFE_ENVIRONMENT: development
+          TERRASAFE_DATABASE_URL: "postgresql+asyncpg://test:test@localhost:5432/test"
+          TERRASAFE_REDIS_URL: "redis://localhost:6379"
+          TERRASAFE_LOG_LEVEL: INFO
+          GATE_REPORT_PATH: gate-report-after-fix.md
+        run: |
+          set +e
+          git pull --ff-only origin "${{ github.event.pull_request.head.ref }}" || true
+          python scripts/quality_gate.py
+          rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "fixed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fixed=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Upload post-fix report
+        if: steps.limits.outputs.proceed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-gate-report-after-fix
+          path: gate-report-after-fix.md
+          retention-days: 14
+
+      - name: Comment on PR with auto-fix result
+        if: steps.limits.outputs.proceed == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const fixed = '${{ steps.verify.outputs.fixed }}' === 'true';
+            const attempt = '${{ steps.limits.outputs.attempt }}';
+            const max     = '${{ steps.limits.outputs.max }}';
+            const after = fs.existsSync('gate-report-after-fix.md')
+              ? fs.readFileSync('gate-report-after-fix.md', 'utf8')
+              : '_Post-fix report missing._';
+            const header = fixed
+              ? `## ✅ Claude auto-fix succeeded (attempt ${attempt}/${max})`
+              : `## ⚠️ Quality Gate still failing after auto-fix attempt ${attempt}/${max}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `${header}\n\n${after}`,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ htmlcov/
 nosetests.xml
 coverage.xml
 .benchmarks/
+gate-report.md
+gate-report-after-fix.md
 # NOTE: .coveragerc is a config file and SHOULD be tracked in git
 
 # ===================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,48 @@ All previously documented issues have been resolved:
 - `Severity.INFO = "INFO"` added to domain enum; `POINTS_INFO = 2` added to `security_rules.py`
 - `update_model_with_feedback()` rewrites to combine historical + new data (no more catastrophic forgetting)
 
+## Quality Gate
+
+Pull requests against `master`/`main` run an automated Quality Gate
+(`.github/workflows/quality-gate.yml`). The gate enforces, in a single
+`scripts/quality_gate.py` invocation:
+
+| Check | Threshold |
+|---|---|
+| pytest | every test passes |
+| coverage | line-rate ≥ 74.00 % |
+| pylint | score = 10.00 / 10 |
+| flake8 | 0 findings |
+| bandit | 0 findings at `-ll` |
+| mypy | 0 errors |
+
+On failure the gate uploads `gate-report.md` as an artifact and comments
+the report on the PR.
+
+### Self-correction loop
+
+Add the `auto-fix` label to the PR to opt in to Claude self-correction:
+
+1. The `auto-fix` job downloads `gate-report.md`.
+2. It invokes `anthropics/claude-code-action@v1` with the failure report
+   and an instruction to apply the minimal change set.
+3. Claude commits any fixes as
+   `chore(quality-gate): auto-fix attempt N` and pushes to the PR branch.
+4. The job re-runs the gate inline and comments the post-fix result.
+5. A 3-attempt limit is enforced by counting prior auto-fix commits.
+
+Optional repository secret `AUTO_FIX_PAT` (a fine-grained PAT with
+`contents: write` on this repo) makes the post-fix push trigger the
+normal Quality Gate workflow on the new SHA. Without it, the inline
+re-verification is authoritative for the current run.
+
+### Run it locally
+
+```bash
+make quality-gate            # full gate, mirrors CI
+python scripts/quality_gate.py
+```
+
 ## Slash Commands
 
 Project-specific slash commands for common workflows:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for TerraSafe - Terraform Security Scanner
-.PHONY: help install test run-demo clean docker lint coverage api metrics test-api security-scan security-deps security-sast security-all setup-hooks
+.PHONY: help install test run-demo clean docker lint coverage api metrics test-api security-scan security-deps security-sast security-all setup-hooks quality-gate
 
 # Variables
 PYTHON := python3
@@ -28,6 +28,7 @@ help:
 	@echo "  make security-deps - Check for vulnerable dependencies"
 	@echo "  make security-sast - Run static security analysis"
 	@echo "  make setup-hooks   - Install pre-commit security hooks"
+	@echo "  make quality-gate  - Run the full Quality Gate (pytest + coverage + pylint + flake8 + bandit + mypy)"
 	@echo "  make clean         - Remove generated files and cache"
 
 # Install dependencies
@@ -170,6 +171,11 @@ security-all: security-scan
 	@echo "🔒 Running comprehensive security audit..."
 	@echo "Checking for secrets..."
 	@git secrets --scan || echo "Install git-secrets for secret detection"
+
+# Run the Quality Gate locally (mirror of the GitHub Actions check)
+quality-gate: install
+	@echo "🚦 Running Quality Gate..."
+	$(VENV)/bin/python scripts/quality_gate.py
 
 # Pre-commit setup
 setup-hooks: install

--- a/scripts/quality_gate.py
+++ b/scripts/quality_gate.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Run the TerraSafe Quality Gate.
+
+Single source of truth for CI and local runs. Executes every check and
+emits a structured Markdown report at $GATE_REPORT_PATH (default:
+``gate-report.md``). Exits 0 if every check passes, 1 otherwise.
+
+Thresholds (must match CLAUDE.md health stats):
+  - pytest: every test passes
+  - coverage: line-rate >= 74.00 %
+  - pylint: score == 10.00 / 10
+  - flake8: 0 findings
+  - bandit: 0 findings at -ll severity
+  - mypy: 0 errors
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORT_PATH = Path(os.environ.get("GATE_REPORT_PATH", REPO_ROOT / "gate-report.md"))
+
+COVERAGE_FLOOR = 74.0
+PYLINT_FLOOR = 10.0
+DETAIL_TAIL_CHARS = 4000
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    summary: str
+    details: str = ""
+
+
+def _run(cmd: List[str]) -> Tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _tail(text: str) -> str:
+    if len(text) <= DETAIL_TAIL_CHARS:
+        return text
+    return "... (truncated) ...\n" + text[-DETAIL_TAIL_CHARS:]
+
+
+def check_pytest() -> CheckResult:
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--cov=terrasafe",
+            "--cov-report=xml",
+            "--cov-report=term-missing",
+        ]
+    )
+    if code != 0:
+        return CheckResult("pytest", False, "Tests failed", _tail(out))
+    return CheckResult("pytest", True, "All tests passed")
+
+
+def check_coverage() -> CheckResult:
+    xml_path = REPO_ROOT / "coverage.xml"
+    if not xml_path.exists():
+        return CheckResult(
+            "coverage",
+            False,
+            "coverage.xml missing — pytest with --cov did not run",
+        )
+    tree = ET.parse(xml_path)
+    rate = float(tree.getroot().attrib.get("line-rate", "0")) * 100
+    summary = f"Line coverage {rate:.2f}% (floor {COVERAGE_FLOOR:.2f}%)"
+    if rate + 1e-6 < COVERAGE_FLOOR:
+        return CheckResult("coverage", False, summary)
+    return CheckResult("coverage", True, summary)
+
+
+def check_pylint() -> CheckResult:
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "pylint",
+            "terrasafe/",
+            "--score=y",
+        ]
+    )
+    match = re.search(r"Your code has been rated at ([-\d\.]+)/10", out)
+    if not match:
+        return CheckResult(
+            "pylint",
+            False,
+            "Could not parse pylint score",
+            _tail(out),
+        )
+    score = float(match.group(1))
+    summary = f"Pylint score {score:.2f}/10 (floor {PYLINT_FLOOR:.2f}/10)"
+    if score + 1e-6 < PYLINT_FLOOR:
+        return CheckResult("pylint", False, summary, _tail(out))
+    if code != 0:
+        return CheckResult(
+            "pylint",
+            False,
+            f"{summary} but pylint exited {code}",
+            _tail(out),
+        )
+    return CheckResult("pylint", True, summary)
+
+
+def check_flake8() -> CheckResult:
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "flake8",
+            "terrasafe/",
+            "--max-line-length=120",
+            "--exclude=__pycache__",
+            "--ignore=E226,E402,E501,W503,W504",
+        ]
+    )
+    findings = [line for line in out.splitlines() if line.strip()]
+    if code != 0 or findings:
+        return CheckResult(
+            "flake8",
+            False,
+            f"{len(findings)} finding(s)",
+            _tail(out),
+        )
+    return CheckResult("flake8", True, "0 findings")
+
+
+def check_bandit() -> CheckResult:
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "bandit",
+            "-r",
+            "terrasafe/",
+            "--ini",
+            ".bandit",
+            "-ll",
+            "-f",
+            "screen",
+        ]
+    )
+    if code != 0:
+        return CheckResult(
+            "bandit",
+            False,
+            "Findings detected at -ll severity",
+            _tail(out),
+        )
+    return CheckResult("bandit", True, "0 findings at -ll severity")
+
+
+def check_mypy() -> CheckResult:
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "terrasafe/",
+            "--ignore-missing-imports",
+        ]
+    )
+    if code != 0:
+        return CheckResult("mypy", False, "Type errors", _tail(out))
+    return CheckResult("mypy", True, "0 errors")
+
+
+CHECKS: List[Callable[[], CheckResult]] = [
+    check_pytest,
+    check_coverage,
+    check_pylint,
+    check_flake8,
+    check_bandit,
+    check_mypy,
+]
+
+
+def render_report(results: List[CheckResult]) -> str:
+    overall_pass = all(r.passed for r in results)
+    lines = [
+        "# TerraSafe Quality Gate Report",
+        "",
+        f"**Overall:** {'PASSED ✅' if overall_pass else 'FAILED ❌'}",
+        "",
+        "| Check | Status | Summary |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        lines.append(f"| {result.name} | {status} | {result.summary} |")
+    lines.append("")
+
+    failed = [r for r in results if not r.passed]
+    if failed:
+        lines.append("## Failure details")
+        lines.append("")
+        for result in failed:
+            lines.append(f"### {result.name} — {result.summary}")
+            lines.append("")
+            lines.append("```")
+            lines.append(result.details or "(no captured output)")
+            lines.append("```")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    results: List[CheckResult] = []
+    for check in CHECKS:
+        marker = check.__name__.replace("check_", "")
+        print(f"::group::{marker}", flush=True)
+        result = check()
+        status = "PASS" if result.passed else "FAIL"
+        print(f"[{status}] {result.summary}", flush=True)
+        results.append(result)
+        print("::endgroup::", flush=True)
+
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(render_report(results), encoding="utf-8")
+    print(f"\nReport written to {REPORT_PATH}", flush=True)
+
+    return 0 if all(r.passed for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terrasafe/api.py
+++ b/terrasafe/api.py
@@ -257,7 +257,7 @@ app.add_middleware(
 # Add rate limiting if available
 if RATE_LIMITING_AVAILABLE:
     app.state.limiter = limiter
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 
 # Middleware for correlation IDs

--- a/terrasafe/infrastructure/database.py
+++ b/terrasafe/infrastructure/database.py
@@ -192,7 +192,7 @@ class DatabaseManager:
 
 
 # Singleton instance
-_db_manager: Optional[DatabaseManager] = None
+_db_manager: Optional[DatabaseManager] = None  # pylint: disable=invalid-name
 
 
 def get_db_manager() -> DatabaseManager:


### PR DESCRIPTION
## Summary
- New `scripts/quality_gate.py` runs pytest + coverage (≥74%) + pylint (==10.00) + flake8 + bandit (-ll) + mypy in one pass, emits `gate-report.md`.
- `.github/workflows/quality-gate.yml` runs the gate on every PR against `master`/`main`, uploads the report as an artifact, and comments the failure summary back on the PR.
- Opt-in `auto-fix` label triggers `anthropics/claude-code-action@v1` with the failure report; commits land as `chore(quality-gate): auto-fix attempt N` (max 3 attempts, enforced by counting prior commits).
- `make quality-gate` mirrors CI locally; `gate-report*.md` ignored from VCS; tiny pylint silence on the database singleton.

## Local verification
| Check | Result |
| --- | --- |
| pytest | PASS — All tests passed |
| coverage | PASS — 74.31% (floor 74.00%) |
| pylint | PASS — 10.00/10 |
| flake8 | PASS — 0 findings |
| bandit | PASS — 0 findings at -ll |
| mypy | PASS — 0 errors |

## Test plan
- [ ] Confirm `gate-report.md` artifact uploads.
- [ ] (Optional) Apply `auto-fix` label on a deliberately broken commit to exercise the self-correction job end-to-end.
- [ ] Quality Gate workflow runs green on this PR (first invocation).
- [ ] Confirm `make quality-gate` still passes after merge to `master`.

## Notes
- Branch renamed from `feat/pr-quality-gate` → `feat-pr-quality-gate` because origin already has a `refs/heads/feat` branch occupying the `feat/*` namespace.
- `AUTO_FIX_PAT` repo secret is optional; without it the inline post-fix verification is authoritative for the current run.