### PR TITLE
ci: restrict Claude workflows to repo owner only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   claude-review:
+    # Only the repo owner may run this review.
+    if: github.actor == 'oguarni'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude:
+    # Only the repo owner may trigger Claude — prevents anyone on this public
+    # repo from spending CLAUDE_CODE_OAUTH_TOKEN by commenting @claude.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'oguarni' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Gate both Claude GitHub workflows on `github.actor == 'oguarni'` so only the repo owner can trigger them.

- `claude.yml` — previously *any* GitHub user could trigger it by commenting `@claude` on an issue/PR. On a public repo, `issue_comment` events run with repo secrets available, so this was the one real exposure of `CLAUDE_CODE_OAUTH_TOKEN`.
- `claude-code-review.yml` — added an explicit owner guard (already collaborator-only via `workflow_dispatch`).

## History audit (no abuse found)

- `claude.yml`: 1 run ever (2026-05-18), `issue_comment`, **skipped**, by `oguarni`. No token spent.
- `claude-code-review.yml`: all 10 runs were `oguarni` on same-repo branches (`oguarni/terravault`). No forks, no external actors.
- `quality-gate.yml` auto-fix: already gated on same-repo PRs + `auto-fix` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)