### PR TITLE
ci: pin third-party actions to SHAs + supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned to SHAs but auto-bumped when upstream releases.
+  # Dependabot updates the pinned commit and the trailing "# vX" comment together.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/devsecops.yml
+++ b/.github/workflows/devsecops.yml
@@ -142,7 +142,7 @@ jobs:
         if-no-files-found: warn
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         files: ./coverage.xml
         fail_ci_if_error: false
@@ -196,14 +196,14 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build Docker image
       run: |
         docker build -t terravault:${{ github.sha }} .
 
     - name: Run Trivy on Docker image
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         image-ref: 'terravault:${{ github.sha }}'
         format: 'sarif'
@@ -425,7 +425,7 @@ jobs:
 
       - name: Run Claude DevSecOps auto-fix
         if: steps.limits.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1 # v1
         env:
           TERRAVAULT_API_KEY_HASH: "$2b$12$LJ3m9ZkRjWyEbhMxBqXvkuN/3QlGYbTEwHqMFEVBBxkLpN0uWxjAq"
           TERRAVAULT_ENVIRONMENT: development
@@ -490,7 +490,7 @@ jobs:
               4. Stage and commit:
                    git add -A
                    git commit -m "chore(devsecops): auto-fix attempt ${{ steps.limits.outputs.attempt }}"
-                   git push origin HEAD:${{ github.event.pull_request.head.ref }}
+                   git push origin HEAD:"$PR_BRANCH"
 
             Hard constraints:
               - Do NOT add features, refactors, or abstractions beyond what the
@@ -511,9 +511,10 @@ jobs:
           TERRAVAULT_DATABASE_URL: "postgresql+asyncpg://test:test@localhost:5432/test"
           TERRAVAULT_REDIS_URL: "redis://localhost:6379"
           TERRAVAULT_LOG_LEVEL: INFO
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           set +e
-          git pull --ff-only origin "${{ github.event.pull_request.head.ref }}" || true
+          git pull --ff-only origin "$PR_BRANCH" || true
           mkdir -p _verify
           bandit -r terravault/ --ini .bandit -f json -o _verify/bandit-report.json -ll || true
           safety check --save-json _verify/safety-report.json || true

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Run Claude auto-fix
         if: steps.limits.outputs.proceed == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1 # v1
         env:
           API_USERNAME: ${{ secrets.API_USERNAME }}
           API_PASSWORD: ${{ secrets.API_PASSWORD }}
@@ -232,7 +232,7 @@ jobs:
                    `git add -A`
                    `git commit -m "chore(quality-gate): auto-fix attempt ${{ steps.limits.outputs.attempt }}"`
               6. Push to the PR branch:
-                   `git push origin HEAD:${{ github.event.pull_request.head.ref }}`
+                   `git push origin HEAD:"$PR_BRANCH"`
 
             Hard constraints:
               - Do NOT add features, refactors, or abstractions beyond what the
@@ -258,9 +258,10 @@ jobs:
           TERRAVAULT_LOG_LEVEL: INFO
           GATE_REPORT_PATH: gate-report-after-fix.md
           GATE_METRICS_PATH: gate-metrics-after-fix.json
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           set +e
-          git pull --ff-only origin "${{ github.event.pull_request.head.ref }}" || true
+          git pull --ff-only origin "$PR_BRANCH" || true
           python scripts/quality_gate.py
           rc=$?
           if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
Closes the supply-chain attack surface on this public repo.

## Changes
- **Pin all third-party actions to commit SHAs** (tags can be hijacked upstream; a moved tag would run inside our job with `CLAUDE_CODE_OAUTH_TOKEN`):
  - `anthropics/claude-code-action` → `20c8abf` # v1 (claude.yml, claude-code-review.yml, quality-gate.yml, devsecops.yml)
  - `codecov/codecov-action` → `b9fd7d1` # v4
  - `docker/setup-buildx-action` → `8d2750c` # v3
  - `aquasecurity/trivy-action` → `57a97c7` # 0.35.0
- **Branch-name handling**: pass `head.ref` via the `PR_BRANCH` env var instead of splicing it into `run:`/prompt shell lines (defense-in-depth vs. injection; the jobs are already same-repo + label gated).
- **Dependabot** (`github-actions`, weekly) to keep the pinned SHAs current.

GitHub-owned actions (`actions/*`, `github/codeql-action`) left on tags by choice — lower supply-chain risk; Dependabot will surface updates regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)