### PR TITLE
chore(gitignore): ignore runtime backups/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@
 .git.bak/
 
 # ===================================
+# Database backups (runtime dumps)
+# ===================================
+# Local output dir for scripts/backup_db.sh on the deploy VM before the dump
+# is shipped to GCS. Untracked runtime artifacts — keep the deploy working
+# tree clean so scripts/deploy_vm.sh's dirty-tree guard does not abort.
+backups/
+
+# ===================================
 # Python
 # ===================================
 __pycache__/


### PR DESCRIPTION
## What
Add `backups/` to `.gitignore`.

## Why
The deploy VM's `scripts/backup_db.sh` writes DB dumps to `./backups` before shipping them to GCS. The directory was untracked and not ignored, so it left the working tree dirty on the VM. That tripped the dirty-tree guard in `scripts/deploy_vm.sh`, which aborts before fast-forwarding — blocking unattended/health-gated deploys.

## Effect
- Keeps the deploy working tree clean so `scripts/deploy_vm.sh` runs unattended.
- Pure runtime artifact; nothing tracked is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)