### PR TITLE
fix(deps): bump python-multipart to 0.0.27 (CVE-2026-24486, -42561)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ joblib==1.4.2
 # API and web framework
 fastapi==0.131.0
 uvicorn[standard]==0.34.0
-python-multipart==0.0.20
+python-multipart==0.0.27
 
 # Configuration and environment
 python-dotenv==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "redis",
         "bcrypt",
         "aiofiles",
-        "python-multipart",
+        "python-multipart>=0.0.27",
         "python-dotenv",
         "slowapi",
         "prometheus-client",


### PR DESCRIPTION
## What
Bump `python-multipart` `0.0.20` → `0.0.27` in `requirements.txt`; add `>=0.0.27` floor in `setup.py`.

## Why
`python-multipart` parses the multipart body of the **public file-upload endpoint** `scan_terraform` (`terravault/api.py`, `UploadFile = File(...)`), reachable over the internet via Caddy. The pinned `0.0.20` is vulnerable to:
- **CVE-2026-24486** — path-traversal arbitrary file write (fixed in 0.0.22)
- **CVE-2026-42561** (fixed in 0.0.27)

`0.0.27` clears both. This is the only fixable HIGH/CRITICAL CVE on TerraVault's internet-facing surface (verified with `trivy --severity HIGH,CRITICAL --ignore-unfixed` against the `caddy` and `terravault-api` images). Other Trivy findings are loopback-only services, build-time packaging deps, or an upstream Caddy `go-jose` fix we don't control.

## Verification
- CI Quality Gate (pytest, ratchet, pylint, flake8, bandit, mypy) + DevSecOps pipeline.
- Post-merge: rebuild API on the VM and re-run Trivy to confirm the finding clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)