### PR TITLE
fix(rules): close IPv6/port-range exposure gaps + secret false-positives

### DIFF
--- a/terravault/domain/CLAUDE.md
+++ b/terravault/domain/CLAUDE.md
@@ -19,8 +19,8 @@ This layer defines business entities and detection logic. It depends only on `co
 
 | # | Rule | Method | Severity | Notes |
 |---|---|---|---|---|
-| 1 | Open security groups | `check_open_security_groups()` | CRITICAL/HIGH/MEDIUM | Port-specific: SSH(22)/RDP(3389) → CRITICAL, HTTP(80/443) → MEDIUM, other → HIGH |
-| 2 | Hardcoded secrets | `check_hardcoded_secrets()` | CRITICAL | Regex: password, api_key, secret_key, token; excludes `var.` and `${` refs |
+| 1 | Open security groups | `check_open_security_groups()` | CRITICAL/HIGH/MEDIUM | Internet-open over IPv4 (`0.0.0.0/0`) or IPv6 (`::/0`). Severity by port *range*: range covering SSH(22)/RDP(3389) → CRITICAL, HTTP(80/443) → MEDIUM, other → HIGH |
+| 2 | Hardcoded secrets | `check_hardcoded_secrets()` | CRITICAL | Regex: password, api_key, secret_key, token; `_is_parametrized()` excludes `${...}` interpolations (anywhere) and `var.`/`local.`/`data.`/`module.`/`each.`/`count.` refs |
 | 3 | Unencrypted storage | `check_encryption()` | HIGH | RDS (`storage_encrypted`) + EBS (`encrypted`) |
 | 4 | Public S3 | `check_public_s3()` | HIGH/MEDIUM | 4 boolean settings; >=3 disabled → HIGH, >0 → MEDIUM |
 | 5 | IAM policies | `check_iam_policies()` | CRITICAL | Wildcard actions + full admin (`*`/`*`) detection |

--- a/terravault/domain/security_rules.py
+++ b/terravault/domain/security_rules.py
@@ -12,72 +12,135 @@ POINTS_MEDIUM = 10
 POINTS_LOW = 5
 POINTS_INFO = 2
 
+# Network exposure constants
+SSH_PORT = 22
+RDP_PORT = 3389
+WEB_PORTS = (80, 443)
+OPEN_IPV4 = "0.0.0.0/0"  # any IPv4 address
+OPEN_IPV6 = "::/0"       # any IPv6 address
+
 
 class SecurityRuleEngine:
     """Rule-based security detection engine following SRP"""
 
+    @staticmethod
+    def _iter_named_resources(tf_content: Dict, resource_type: str):
+        """Yield (name, config) for every resource of ``resource_type``.
+
+        Normalises the HCL list/dict ambiguity so callers never repeat the
+        ``isinstance`` dance.
+        """
+        for resource in tf_content.get('resource', []):
+            if resource_type not in resource:
+                continue
+            block = resource[resource_type]
+            items = block if isinstance(block, list) else [block]
+            for item in items:
+                if isinstance(item, dict):
+                    yield from item.items()
+
+    @staticmethod
+    def _open_scopes(ingress: Dict) -> List[str]:
+        """Return the internet-open CIDR scopes on an ingress rule.
+
+        Covers both IPv4 (``0.0.0.0/0``) and IPv6 (``::/0``) — a rule open over
+        IPv6 only is just as reachable as one open over IPv4.
+        """
+        scopes = []
+        if OPEN_IPV4 in (ingress.get('cidr_blocks') or []):
+            scopes.append(OPEN_IPV4)
+        if OPEN_IPV6 in (ingress.get('ipv6_cidr_blocks') or []):
+            scopes.append(OPEN_IPV6)
+        return scopes
+
+    @staticmethod
+    def _port_range(ingress: Dict) -> tuple:
+        """Normalise (from_port, to_port) to a sorted int tuple; (0, 0) on bad input."""
+        raw_from = ingress.get('from_port', 0)
+        raw_to = ingress.get('to_port', raw_from)
+        try:
+            low, high = int(raw_from), int(raw_to)
+        except (TypeError, ValueError):
+            return 0, 0
+        return (low, high) if low <= high else (high, low)
+
+    def _classify_open_ingress(self, ingress: Dict, sg_name: str):
+        """Return a Vulnerability for an internet-open ingress rule, or None.
+
+        Severity is decided by whether the port *range* covers a sensitive port,
+        so wide ranges (e.g. 0-65535) are still caught as CRITICAL rather than
+        slipping past an exact-match check.
+        """
+        scopes = self._open_scopes(ingress)
+        if not scopes:
+            return None
+
+        low, high = self._port_range(ingress)
+        scope = " / ".join(scopes)
+        port_label = str(low) if low == high else f"{low}-{high}"
+
+        if low <= SSH_PORT <= high:
+            return Vulnerability(
+                severity=Severity.CRITICAL, points=POINTS_CRITICAL,
+                message=f"[CRITICAL] Open security group - SSH port 22 exposed to internet ({scope})",
+                resource=sg_name,
+                remediation="Restrict SSH access to specific IP ranges",
+            )
+        if low <= RDP_PORT <= high:
+            return Vulnerability(
+                severity=Severity.CRITICAL, points=POINTS_CRITICAL,
+                message=f"[CRITICAL] Open security group - RDP port 3389 exposed to internet ({scope})",
+                resource=sg_name,
+                remediation="Restrict RDP access to specific IP ranges",
+            )
+        if any(low <= web_port <= high for web_port in WEB_PORTS):
+            return Vulnerability(
+                severity=Severity.MEDIUM, points=POINTS_MEDIUM,
+                message=f"[MEDIUM] HTTP/HTTPS port {port_label} exposed to internet ({scope})",
+                resource=sg_name,
+                remediation="Consider using a CDN or WAF for public web services",
+            )
+        return Vulnerability(
+            severity=Severity.HIGH, points=POINTS_HIGH,
+            message=f"[HIGH] Port {port_label} exposed to internet ({scope})",
+            resource=sg_name,
+            remediation="Restrict access to specific IP ranges",
+        )
+
     def check_open_security_groups(self, tf_content: Dict) -> List[Vulnerability]:
-        """Check for security groups with open access (0.0.0.0/0)"""
+        """Check for security groups open to the internet over IPv4 or IPv6."""
         vulns: List[Vulnerability] = []
 
         if 'resource' not in tf_content:
             return vulns
 
-        for resource in tf_content.get('resource', []):
-            if 'aws_security_group' in resource:
-                sg_list = resource['aws_security_group']
-                # Handle both list and dict formats
-                if isinstance(sg_list, list):
-                    sg_items = sg_list
-                else:
-                    sg_items = [sg_list]
-
-                for sg_item in sg_items:
-                    if isinstance(sg_item, dict):
-                        for sg_name, sg_config in sg_item.items():
-                            # Check ingress rules
-                            for ingress in sg_config.get('ingress', []):
-                                cidr_blocks = ingress.get('cidr_blocks', [])
-                                from_port = ingress.get('from_port', 0)
-
-                                if '0.0.0.0/0' in cidr_blocks:
-                                    if from_port == 22:
-                                        vulns.append(Vulnerability(
-                                            severity=Severity.CRITICAL,
-                                            points=POINTS_CRITICAL,
-                                            message="[CRITICAL] Open security group - SSH port 22 exposed to internet",
-                                            resource=sg_name,
-                                            remediation="Restrict SSH access to specific IP ranges"
-                                        ))
-                                    elif from_port == 3389:
-                                        vulns.append(Vulnerability(
-                                            severity=Severity.CRITICAL,
-                                            points=POINTS_CRITICAL,
-                                            message=(
-                                                "[CRITICAL] Open security group - RDP port 3389 "
-                                                "exposed to internet"
-                                            ),
-                                            resource=sg_name,
-                                            remediation="Restrict RDP access to specific IP ranges"
-                                        ))
-                                    elif from_port in (80, 443):
-                                        vulns.append(Vulnerability(
-                                            severity=Severity.MEDIUM,
-                                            points=POINTS_MEDIUM,
-                                            message=f"[MEDIUM] HTTP/HTTPS port {from_port} open to internet",
-                                            resource=sg_name,
-                                            remediation="Consider using a CDN or WAF for public web services"
-                                        ))
-                                    else:
-                                        vulns.append(Vulnerability(
-                                            severity=Severity.HIGH,
-                                            points=POINTS_HIGH,
-                                            message=f"[HIGH] Port {from_port} exposed to internet",
-                                            resource=sg_name,
-                                            remediation="Restrict access to specific IP ranges"
-                                        ))
+        for sg_name, sg_config in self._iter_named_resources(tf_content, 'aws_security_group'):
+            ingress_rules = sg_config.get('ingress', [])
+            if isinstance(ingress_rules, dict):
+                ingress_rules = [ingress_rules]
+            for ingress in ingress_rules:
+                if not isinstance(ingress, dict):
+                    continue
+                vuln = self._classify_open_ingress(ingress, sg_name)
+                if vuln is not None:
+                    vulns.append(vuln)
 
         return vulns
+
+    # Quoted values that are really references, not literal secrets.
+    _REFERENCE_PREFIXES = ('var.', 'local.', 'data.', 'module.', 'each.', 'count.')
+
+    @classmethod
+    def _is_parametrized(cls, value: str) -> bool:
+        """True if a quoted value is a Terraform reference, not a literal secret.
+
+        Excludes ``${...}`` interpolations anywhere in the value (so partial
+        interpolations like ``"prefix-${var.x}"`` are not false-positives) and
+        bare references such as ``var.x`` or ``data.y.z``.
+        """
+        if '${' in value:
+            return True
+        return value.startswith(cls._REFERENCE_PREFIXES)
 
     def check_hardcoded_secrets(self, raw_content: str) -> List[Vulnerability]:
         """Check for hardcoded passwords and secrets using regex"""
@@ -90,8 +153,8 @@ class SecurityRuleEngine:
 
         for match in matches:
             password_value = match.group(1)
-            # Skip if it's a variable reference
-            if not password_value.startswith('var.') and not password_value.startswith('${'):
+            # Skip if it's a variable reference / interpolation
+            if not self._is_parametrized(password_value):
                 vulns.append(Vulnerability(
                     severity=Severity.CRITICAL,
                     points=POINTS_CRITICAL,
@@ -111,7 +174,7 @@ class SecurityRuleEngine:
             matches = re.finditer(pattern, raw_content, re.IGNORECASE)
             for match in matches:
                 value = match.group(1)
-                if not value.startswith('var.') and not value.startswith('${'):
+                if not self._is_parametrized(value):
                     vulns.append(Vulnerability(
                         severity=Severity.CRITICAL,
                         points=POINTS_CRITICAL,

--- a/tests/test_security_rules_network.py
+++ b/tests/test_security_rules_network.py
@@ -1,0 +1,124 @@
+"""Tests for network-exposure and hardcoded-secret rules on ``SecurityRuleEngine``.
+
+These cover the detection-correctness fixes:
+- IPv6 ``::/0`` exposure (previously a silent false-negative)
+- Port *range* coverage of sensitive ports (previously bypassed exact-match)
+- Hardcoded-secret false-positives on interpolated / referenced values
+"""
+import pytest
+
+from terravault.domain.models import Severity
+
+
+pytestmark = pytest.mark.unit
+
+
+def _sg(ingress: dict) -> dict:
+    """Wrap a single ingress block in a parsed-HCL security-group resource."""
+    return {"resource": [{"aws_security_group": [{"sg": {"ingress": [ingress]}}]}]}
+
+
+# ---------------------------------------------------------------------------
+# check_open_security_groups — exposure scope (IPv4 / IPv6) and port ranges
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "ingress, expected_severity, message_fragment",
+    [
+        pytest.param(
+            {"from_port": 22, "to_port": 22, "cidr_blocks": ["0.0.0.0/0"]},
+            Severity.CRITICAL, "SSH port 22",
+            id="ipv4_ssh_is_critical",
+        ),
+        pytest.param(
+            {"from_port": 22, "to_port": 22, "ipv6_cidr_blocks": ["::/0"]},
+            Severity.CRITICAL, "SSH port 22",
+            id="ipv6_ssh_is_critical",
+        ),
+        pytest.param(
+            {"from_port": 3389, "to_port": 3389, "ipv6_cidr_blocks": ["::/0"]},
+            Severity.CRITICAL, "RDP port 3389",
+            id="ipv6_rdp_is_critical",
+        ),
+        pytest.param(
+            {"from_port": 0, "to_port": 65535, "cidr_blocks": ["0.0.0.0/0"]},
+            Severity.CRITICAL, "SSH port 22",
+            id="wide_range_covering_ssh_is_critical",
+        ),
+        pytest.param(
+            {"from_port": 3380, "to_port": 3400, "cidr_blocks": ["0.0.0.0/0"]},
+            Severity.CRITICAL, "RDP port 3389",
+            id="range_covering_rdp_is_critical",
+        ),
+        pytest.param(
+            {"from_port": 443, "to_port": 443, "cidr_blocks": ["0.0.0.0/0"]},
+            Severity.MEDIUM, "HTTP/HTTPS",
+            id="web_port_is_medium",
+        ),
+        pytest.param(
+            {"from_port": 9200, "to_port": 9200, "cidr_blocks": ["0.0.0.0/0"]},
+            Severity.HIGH, "Port 9200",
+            id="other_port_is_high",
+        ),
+    ],
+)
+def test_open_security_group_severity(engine, ingress, expected_severity, message_fragment):
+    vulns = engine.check_open_security_groups(_sg(ingress))
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == expected_severity
+    assert message_fragment in vulns[0].message
+    assert "exposed to internet" in vulns[0].message
+
+
+@pytest.mark.parametrize(
+    "ingress",
+    [
+        pytest.param({"from_port": 22, "to_port": 22, "cidr_blocks": ["10.0.0.0/8"]}, id="private_ipv4"),
+        pytest.param(
+            {"from_port": 22, "to_port": 22, "ipv6_cidr_blocks": ["2001:db8::/32"]},
+            id="scoped_ipv6",
+        ),
+        pytest.param({"from_port": 443, "to_port": 443}, id="no_cidr_at_all"),
+    ],
+)
+def test_non_internet_ingress_is_silent(engine, ingress):
+    assert engine.check_open_security_groups(_sg(ingress)) == []
+
+
+def test_missing_to_port_defaults_to_from_port(engine):
+    vulns = engine.check_open_security_groups(
+        _sg({"from_port": 22, "cidr_blocks": ["0.0.0.0/0"]})
+    )
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.CRITICAL
+
+
+def test_open_security_groups_handles_empty_content(engine):
+    assert engine.check_open_security_groups({}) == []
+
+
+# ---------------------------------------------------------------------------
+# check_hardcoded_secrets — literals flagged, references ignored
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, should_flag",
+    [
+        pytest.param('password = "hardcoded123"', True, id="literal_password_flagged"),
+        pytest.param('api_key = "AKIAEXAMPLE12345"', True, id="literal_api_key_flagged"),
+        pytest.param('token = "ghp_realtokenvalue"', True, id="literal_token_flagged"),
+        pytest.param('password = "${var.db_password}"', False, id="interpolated_var_ignored"),
+        pytest.param('password = "prefix-${var.x}"', False, id="partial_interpolation_ignored"),
+        pytest.param('secret_key = "${data.aws_ssm.k.value}"', False, id="data_reference_ignored"),
+        pytest.param('password = "var.db_password"', False, id="bare_var_reference_ignored"),
+        pytest.param('password = "local.secret"', False, id="bare_local_reference_ignored"),
+    ],
+)
+def test_hardcoded_secret_detection(engine, raw, should_flag):
+    vulns = engine.check_hardcoded_secrets(raw)
+
+    assert bool(vulns) is should_flag
+    if should_flag:
+        assert all(v.severity == Severity.CRITICAL for v in vulns)


### PR DESCRIPTION
## What & why

The flagship `check_open_security_groups` rule had two demonstrable detection gaps, confirmed by probing the live parser output:

| Scenario | Before | After |
|---|---|---|
| SSH/RDP open to the world over **IPv6** (`ipv6_cidr_blocks = ["::/0"]`) | **no finding** (silent FN) | CRITICAL |
| Wide port range (`0-65535`) over `0.0.0.0/0` covering SSH+RDP | `[HIGH] Port 0 exposed` (mislabeled) | CRITICAL |
| Range covering RDP (e.g. `3380-3400`) | missed | CRITICAL |

It only matched IPv4 `0.0.0.0/0` and classified severity by an **exact** `from_port` match, so anything open over IPv6 or via a port *range* slipped past.

### Changes

- `check_open_security_groups` now treats both `0.0.0.0/0` and `::/0` as internet-open, and classifies severity by whether the port **range** covers a sensitive port (SSH 22 / RDP 3389 → CRITICAL, HTTP 80/443 → MEDIUM, else HIGH). Findings now name the exposure scope, e.g. `... exposed to internet (::/0)`.
- Refactored into focused helpers (`_iter_named_resources`, `_open_scopes`, `_port_range`, `_classify_open_ingress`) to cut nesting — keeps pylint at 10.00.
- `check_hardcoded_secrets` gains `_is_parametrized()`, which excludes `${...}` interpolations **anywhere** in the value (not just at the start) plus bare `var.`/`local.`/`data.`/`module.`/`each.`/`count.` references — removes the `"prefix-${var.x}"` false-positive.

### Tests / gate

- New `tests/test_security_rules_network.py` (20 cases) covering IPv4/IPv6 scope, port-range severity, private-CIDR silence, and secret literal-vs-reference.
- Local gate green: **105 tests**, coverage **74.31% → 75.59%**, ratchet PASS, pylint **10.00**, flake8 **0**, mypy **0**, bandit **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)