### PR TITLE
feat(rules): expand detection engine from 7 to 11 security rules

### DIFF
--- a/.ratchet.json
+++ b/.ratchet.json
@@ -1,5 +1,5 @@
 {
-  "coverage_pct": 75.77,
+  "coverage_pct": 76.49,
   "files_over_threshold": 5,
   "duplicate_blocks": 0,
   "thresholds": {
@@ -7,5 +7,5 @@
     "min_similarity_lines": 4
   },
   "updated_at": "2026-06-09",
-  "updated_commit": "e9bae1320133f40dced5a1f518f5d74065080fc4"
+  "updated_commit": "9ba6b754cd38352f57073118c8cc58ad297a6590"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 TerraVault is a hybrid Terraform security scanner implementing Clean Architecture with:
 - **Architecture**: Clean Architecture layers (domain → application → infrastructure)
-- **Security Approach**: 60% rule-based detection (7 rules) + 40% ML anomaly detection (8-dim *structural* feature vector, independent of the rule findings)
+- **Security Approach**: 60% rule-based detection (11 rules) + 40% ML anomaly detection (8-dim *structural* feature vector, independent of the rule findings)
 - **Tech Stack**: FastAPI, PostgreSQL, Redis, Isolation Forest ML, Prometheus/Grafana
 - **Language**: Python 3.10+
 - **Health**: focused test suite (72 pytest cases, 74% line coverage on 1,518 SLOC) on security rules, scan pipeline, API contract, and ML predictions; Pylint 10.00/10, 0 Flake8 issues, 0 Bandit findings, 0 Safety advisories, 0 mypy errors
@@ -124,7 +124,7 @@ Subdirectory CLAUDE.md files provide focused instructions per architectural laye
 |---|---|---|
 | Entry Points | `terravault/CLAUDE.md` | API, CLI, formatters, metrics, middleware |
 | Config | `terravault/config/CLAUDE.md` | Settings (Pydantic), structured logging, correlation IDs |
-| Domain | `terravault/domain/CLAUDE.md` | 7 security rules, severity model, rule inventory, severity overrides |
+| Domain | `terravault/domain/CLAUDE.md` | 11 security rules, severity model, rule inventory, severity overrides |
 | Application | `terravault/application/CLAUDE.md` | Scan pipeline, scoring, caching, 8-dim structural feature extraction |
 | Infrastructure | `terravault/infrastructure/CLAUDE.md` | DB, cache, parser, repositories, rate limiter |
 | ML System | `terravault/infrastructure/CLAUDE_ML.md` | IsolationForest, training, drift detection, model files |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
   <br>
 
-  Catch Terraform misconfigurations, hardcoded secrets, and risky infrastructure patterns before they reach production. TerraVault pairs **7 deterministic detection rules** with **Isolation Forest anomaly detection** to surface both known violations and deviations from learned secure baselines.
+  Catch Terraform misconfigurations, hardcoded secrets, and risky infrastructure patterns before they reach production. TerraVault pairs **11 deterministic detection rules** with **Isolation Forest anomaly detection** to surface both known violations and deviations from learned secure baselines.
 
 </div>
 
@@ -51,7 +51,7 @@
 ## Features
 
 ### Security Scanner
-- Pattern matching for **7 vulnerability categories**: open ports, hardcoded secrets, unencrypted storage, public S3 buckets, IAM misconfigurations, missing CloudWatch logging, and missing VPC flow logs
+- Pattern matching for **11 vulnerability categories**: open ports, hardcoded secrets, unencrypted storage, public S3 buckets, IAM misconfigurations, missing CloudWatch logging, missing VPC flow logs, publicly accessible RDS, unrestricted security-group egress, EC2 instances allowing IMDSv1, and EC2 instances with auto-assigned public IPs
 - Severity classification: `CRITICAL` · `HIGH` · `MEDIUM` · `LOW` · `INFO`
 - Actionable remediation suggestions per finding
 - Configurable severity overrides for organizational policy alignment

--- a/terravault/domain/CLAUDE.md
+++ b/terravault/domain/CLAUDE.md
@@ -12,7 +12,7 @@ This layer defines business entities and detection logic. It depends only on `co
 - **Naming collision**: `Vulnerability` here conflicts with the ORM model in `infrastructure/models.py`. Repositories import it as `DomainVulnerability` alias.
 
 ### `security_rules.py`
-- `SecurityRuleEngine` — 7 rule checks, point constants: `CRITICAL=30`, `HIGH=20`, `MEDIUM=10`, `LOW=5`, `INFO=2`
+- `SecurityRuleEngine` — 11 rule checks, point constants: `CRITICAL=30`, `HIGH=20`, `MEDIUM=10`, `LOW=5`, `INFO=2`
 - `analyze(tf_content, raw_content)` aggregates all checks and applies `severity_overrides` from settings — **new rules must be registered here**
 
 ## Rule Inventory
@@ -26,6 +26,10 @@ This layer defines business entities and detection logic. It depends only on `co
 | 5 | IAM policies | `check_iam_policies()` | CRITICAL | Wildcard actions + full admin (`*`/`*`) detection |
 | 6 | Missing logging | `check_missing_logging()` | HIGH | Flags if infra resources exist but no CloudTrail/CloudWatch |
 | 7 | Missing VPC flow logs | `check_missing_vpc_flow_logs()` | MEDIUM | Flags if `aws_vpc` exists but no `aws_flow_log` |
+| 8 | Public RDS | `check_public_rds()` | CRITICAL | `aws_db_instance` with `publicly_accessible = true` (truthy via `_truthy()`) |
+| 9 | Unrestricted egress | `check_unrestricted_egress()` | LOW | `aws_security_group` `egress` open to `0.0.0.0/0`/`::/0` (reuses `_open_scopes()`) |
+| 10 | IMDSv1 allowed | `check_imdsv2_required()` | HIGH | `aws_instance` without `metadata_options { http_tokens = "required" }`; absence also flagged (IMDSv1 is the default) |
+| 11 | Public EC2 instance | `check_public_instance()` | LOW | `aws_instance` with `associate_public_ip_address = true` |
 
 ### Severity Overrides
 

--- a/terravault/domain/security_rules.py
+++ b/terravault/domain/security_rules.py
@@ -40,6 +40,20 @@ class SecurityRuleEngine:
                     yield from item.items()
 
     @staticmethod
+    def _truthy(value) -> bool:
+        """Interpret an HCL attribute as a boolean.
+
+        ``hcl2`` parses ``true``/``false`` to Python bools, but ``.tf.json`` and
+        quoted values can arrive as the strings ``"true"``/``"false"`` — treat
+        both consistently so a string ``"true"`` is not silently falsy.
+        """
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+        return bool(value)
+
+    @staticmethod
     def _open_scopes(ingress: Dict) -> List[str]:
         """Return the internet-open CIDR scopes on an ingress rule.
 
@@ -386,6 +400,125 @@ class SecurityRuleEngine:
 
         return vulns
 
+    def check_public_rds(self, tf_content: Dict) -> List[Vulnerability]:
+        """Flag RDS instances reachable from the public internet.
+
+        ``publicly_accessible = true`` gives the database a public endpoint, so a
+        single weak credential or SG mistake exposes it directly — independent of
+        whether storage is encrypted.
+        """
+        vulns: List[Vulnerability] = []
+
+        if 'resource' not in tf_content:
+            return vulns
+
+        for db_name, db_config in self._iter_named_resources(tf_content, 'aws_db_instance'):
+            if self._truthy(db_config.get('publicly_accessible', False)):
+                vulns.append(Vulnerability(
+                    severity=Severity.CRITICAL,
+                    points=POINTS_CRITICAL,
+                    message="[CRITICAL] Publicly accessible RDS instance - database reachable from the internet",
+                    resource=db_name,
+                    remediation="Set publicly_accessible = false and place the instance in a private subnet",
+                ))
+
+        return vulns
+
+    def check_unrestricted_egress(self, tf_content: Dict) -> List[Vulnerability]:
+        """Flag security groups whose egress is open to the entire internet.
+
+        Unrestricted outbound traffic lets a compromised host exfiltrate data or
+        reach command-and-control infrastructure anywhere; egress should be
+        scoped to the destinations the workload actually needs.
+        """
+        vulns: List[Vulnerability] = []
+
+        if 'resource' not in tf_content:
+            return vulns
+
+        for sg_name, sg_config in self._iter_named_resources(tf_content, 'aws_security_group'):
+            egress_rules = sg_config.get('egress', [])
+            if isinstance(egress_rules, dict):
+                egress_rules = [egress_rules]
+            for egress in egress_rules:
+                if not isinstance(egress, dict):
+                    continue
+                scopes = self._open_scopes(egress)
+                if scopes:
+                    vulns.append(Vulnerability(
+                        severity=Severity.LOW,
+                        points=POINTS_LOW,
+                        message=f"[LOW] Unrestricted egress - outbound traffic open to internet ({' / '.join(scopes)})",
+                        resource=sg_name,
+                        remediation="Restrict egress to the specific destinations the workload needs",
+                    ))
+
+        return vulns
+
+    @staticmethod
+    def _metadata_http_tokens(inst_config: Dict):
+        """Return the ``http_tokens`` value from an instance's ``metadata_options``.
+
+        Normalises the HCL block/list ambiguity; returns None when no
+        ``metadata_options`` block is present.
+        """
+        metadata = inst_config.get('metadata_options')
+        if isinstance(metadata, list):
+            metadata = metadata[0] if metadata else None
+        if isinstance(metadata, dict):
+            return metadata.get('http_tokens')
+        return None
+
+    def check_imdsv2_required(self, tf_content: Dict) -> List[Vulnerability]:
+        """Flag EC2 instances that still allow IMDSv1.
+
+        IMDSv1's unauthenticated metadata endpoint turns any SSRF into instance
+        credential theft (the 2019 Capital One breach). IMDSv2 closes this by
+        requiring a session token — enforced with
+        ``metadata_options { http_tokens = "required" }``. An instance with no
+        ``metadata_options`` defaults to IMDSv1, so absence is also flagged.
+        """
+        vulns: List[Vulnerability] = []
+
+        if 'resource' not in tf_content:
+            return vulns
+
+        for inst_name, inst_config in self._iter_named_resources(tf_content, 'aws_instance'):
+            http_tokens = self._metadata_http_tokens(inst_config)
+            if not (isinstance(http_tokens, str) and http_tokens.lower() == 'required'):
+                vulns.append(Vulnerability(
+                    severity=Severity.HIGH,
+                    points=POINTS_HIGH,
+                    message="[HIGH] EC2 instance allows IMDSv1 - metadata endpoint not protected by IMDSv2",
+                    resource=inst_name,
+                    remediation='Set metadata_options { http_tokens = "required" } to enforce IMDSv2',
+                ))
+
+        return vulns
+
+    def check_public_instance(self, tf_content: Dict) -> List[Vulnerability]:
+        """Flag EC2 instances that auto-assign a public IP address.
+
+        ``associate_public_ip_address = true`` puts the host directly on the
+        internet; workloads should sit behind a NAT gateway or load balancer.
+        """
+        vulns: List[Vulnerability] = []
+
+        if 'resource' not in tf_content:
+            return vulns
+
+        for inst_name, inst_config in self._iter_named_resources(tf_content, 'aws_instance'):
+            if self._truthy(inst_config.get('associate_public_ip_address', False)):
+                vulns.append(Vulnerability(
+                    severity=Severity.LOW,
+                    points=POINTS_LOW,
+                    message="[LOW] EC2 instance auto-assigns a public IP - host directly exposed to the internet",
+                    resource=inst_name,
+                    remediation="Set associate_public_ip_address = false and route through a NAT gateway / LB",
+                ))
+
+        return vulns
+
     def analyze(self, tf_content: Dict, raw_content: str) -> List[Vulnerability]:
         """Run all security checks"""
         all_vulns = []
@@ -398,6 +531,10 @@ class SecurityRuleEngine:
         all_vulns.extend(self.check_iam_policies(tf_content))
         all_vulns.extend(self.check_missing_logging(tf_content))
         all_vulns.extend(self.check_missing_vpc_flow_logs(tf_content))
+        all_vulns.extend(self.check_public_rds(tf_content))
+        all_vulns.extend(self.check_unrestricted_egress(tf_content))
+        all_vulns.extend(self.check_imdsv2_required(tf_content))
+        all_vulns.extend(self.check_public_instance(tf_content))
 
         # Apply severity overrides from config
         overrides = get_settings().severity_overrides

--- a/terravault/infrastructure/CLAUDE_ML.md
+++ b/terravault/infrastructure/CLAUDE_ML.md
@@ -16,7 +16,7 @@
 The model scores the **structure of the infrastructure**, extracted directly
 from the parsed Terraform by `application/feature_extraction.py`
 (`StructuralFeatureExtractor`). It is **not** derived from the rule findings, so
-the ML signal can flag anomalous configurations the 7 rules do not cover. The
+the ML signal can flag anomalous configurations the fixed rule set does not cover. The
 canonical layout lives in `feature_extraction.FEATURE_NAMES` / `FEATURE_BOUNDS`.
 
 | Index | Feature | Bounds | Meaning |

--- a/test_files/secure.tf
+++ b/test_files/secure.tf
@@ -18,6 +18,13 @@ resource "aws_security_group" "web_sg" {
     protocol    = "tcp"
     cidr_blocks = ["10.0.1.0/24"]  # SSH restricted to specific subnet
   }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]  # Egress scoped to the private network
+  }
 }
 
 resource "aws_db_instance" "main_db" {
@@ -30,12 +37,24 @@ resource "aws_db_instance" "main_db" {
   username               = "admin"
   password               = var.db_password  # Using variable instead of hardcoded
   storage_encrypted      = true             # Encryption enabled
+  publicly_accessible    = false            # Database kept off the public internet
   backup_retention_period = 7
   skip_final_snapshot    = false
-  
+
   tags = {
     Environment = "production"
     Encrypted   = "true"
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0123456789abcdef0"
+  instance_type = "t3.micro"
+
+  associate_public_ip_address = false  # No auto-assigned public IP
+
+  metadata_options {
+    http_tokens = "required"  # IMDSv2 enforced — blocks SSRF credential theft
   }
 }
 

--- a/test_files/vulnerable.tf
+++ b/test_files/vulnerable.tf
@@ -18,6 +18,13 @@ resource "aws_security_group" "web_sg" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]  # CRITICAL: Open HTTP access from internet
   }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]  # LOW: Unrestricted egress to the internet
+  }
 }
 
 resource "aws_db_instance" "main_db" {
@@ -30,8 +37,18 @@ resource "aws_db_instance" "main_db" {
   username               = "admin"
   password               = "hardcoded123"  # CRITICAL: Hardcoded password
   storage_encrypted      = false           # HIGH: Unencrypted RDS instance
+  publicly_accessible    = true            # CRITICAL: Database reachable from the internet
   backup_retention_period = 0
   skip_final_snapshot    = true
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0123456789abcdef0"
+  instance_type = "t3.micro"
+
+  associate_public_ip_address = true  # LOW: Auto-assigns a public IP
+
+  # NOTE: no metadata_options block → IMDSv1 allowed (HIGH: SSRF → credential theft)
 }
 
 resource "aws_ebs_volume" "data_volume" {

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -105,14 +105,15 @@ def test_secret_parametrization_separates_literals_from_variables():
 def test_features_are_independent_of_the_rule_engine():
     """A rule-clean but structurally exposed config must still register.
 
-    ``aws_instance`` with a public IP is not covered by any of the 7 rules, so
-    the rule engine returns no findings — yet the structural extractor records
-    the public exposure. This is the behaviour that lets the ML surface risks
-    outside the fixed rule catalogue. A CloudWatch log group is included so the
-    missing-logging rule stays silent and the config is genuinely rule-clean.
+    An ``aws_subnet`` that auto-assigns public IPs (``map_public_ip_on_launch``)
+    is not covered by any rule, so the rule engine returns no findings — yet the
+    structural extractor records the public exposure. This is the behaviour that
+    lets the ML surface risks outside the fixed rule catalogue. A CloudWatch log
+    group is included so the missing-logging rule stays silent and the config is
+    genuinely rule-clean.
     """
     raw = """
-    resource "aws_instance" "web" { associate_public_ip_address = true }
+    resource "aws_subnet" "public" { map_public_ip_on_launch = true }
     resource "aws_cloudwatch_log_group" "g" { name = "g" }
     """
     tf_content = hcl2.loads(raw)

--- a/tests/test_security_rules_resources.py
+++ b/tests/test_security_rules_resources.py
@@ -1,0 +1,215 @@
+"""Tests for the resource-exposure rules on ``SecurityRuleEngine``.
+
+Covers the detection rules added to broaden cloud-misconfiguration coverage:
+- publicly accessible RDS instances
+- unrestricted security-group egress
+- EC2 instances allowing IMDSv1 (no IMDSv2 enforcement)
+- EC2 instances that auto-assign a public IP
+
+Each rule is exercised on both its triggering and non-triggering shapes so the
+detection logic stays fully covered.
+"""
+import pytest
+
+from terravault.domain.models import Severity
+from terravault.domain.security_rules import SecurityRuleEngine
+
+
+pytestmark = pytest.mark.unit
+
+
+def _resources(resource_type: str, name: str, config: dict) -> dict:
+    """Wrap a single named resource in parsed-HCL structure."""
+    return {"resource": [{resource_type: [{name: config}]}]}
+
+
+# ---------------------------------------------------------------------------
+# _truthy — HCL boolean normalisation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param(True, True, id="bool_true"),
+        pytest.param(False, False, id="bool_false"),
+        pytest.param("true", True, id="str_true"),
+        pytest.param("True", True, id="str_true_mixed_case"),
+        pytest.param("false", False, id="str_false"),
+        pytest.param(1, True, id="int_truthy"),
+        pytest.param(0, False, id="int_falsy"),
+    ],
+)
+def test_truthy_normalises_hcl_booleans(value, expected):
+    assert SecurityRuleEngine._truthy(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# check_public_rds
+# ---------------------------------------------------------------------------
+
+def test_public_rds_flagged_as_critical(engine):
+    tf = _resources("aws_db_instance", "main_db", {"publicly_accessible": True})
+
+    vulns = engine.check_public_rds(tf)
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.CRITICAL
+    assert "Publicly accessible RDS" in vulns[0].message
+    assert vulns[0].resource == "main_db"
+
+
+def test_public_rds_string_true_is_flagged(engine):
+    tf = _resources("aws_db_instance", "main_db", {"publicly_accessible": "true"})
+
+    assert len(engine.check_public_rds(tf)) == 1
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"publicly_accessible": False}, id="explicitly_private"),
+        pytest.param({"storage_encrypted": True}, id="attribute_absent"),
+    ],
+)
+def test_private_rds_is_silent(engine, config):
+    assert engine.check_public_rds(_resources("aws_db_instance", "db", config)) == []
+
+
+def test_public_rds_handles_empty_content(engine):
+    assert engine.check_public_rds({}) == []
+
+
+# ---------------------------------------------------------------------------
+# check_unrestricted_egress
+# ---------------------------------------------------------------------------
+
+def test_unrestricted_egress_ipv4_is_low(engine):
+    tf = _resources("aws_security_group", "sg", {"egress": [{"cidr_blocks": ["0.0.0.0/0"]}]})
+
+    vulns = engine.check_unrestricted_egress(tf)
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.LOW
+    assert "Unrestricted egress" in vulns[0].message
+    assert "0.0.0.0/0" in vulns[0].message
+
+
+def test_unrestricted_egress_accepts_single_block_dict(engine):
+    # HCL may parse a lone egress block as a dict rather than a list.
+    tf = _resources("aws_security_group", "sg", {"egress": {"ipv6_cidr_blocks": ["::/0"]}})
+
+    vulns = engine.check_unrestricted_egress(tf)
+
+    assert len(vulns) == 1
+    assert "::/0" in vulns[0].message
+
+
+def test_unrestricted_egress_skips_non_dict_rule(engine):
+    tf = _resources("aws_security_group", "sg", {"egress": ["not-a-dict"]})
+
+    assert engine.check_unrestricted_egress(tf) == []
+
+
+def test_scoped_egress_is_silent(engine):
+    tf = _resources("aws_security_group", "sg", {"egress": [{"cidr_blocks": ["10.0.0.0/8"]}]})
+
+    assert engine.check_unrestricted_egress(tf) == []
+
+
+def test_unrestricted_egress_handles_empty_content(engine):
+    assert engine.check_unrestricted_egress({}) == []
+
+
+# ---------------------------------------------------------------------------
+# check_imdsv2_required
+# ---------------------------------------------------------------------------
+
+def test_imdsv2_required_is_silent(engine):
+    tf = _resources("aws_instance", "web", {"metadata_options": {"http_tokens": "required"}})
+
+    assert engine.check_imdsv2_required(tf) == []
+
+
+def test_imdsv2_required_accepts_list_wrapped_block(engine):
+    tf = _resources("aws_instance", "web", {"metadata_options": [{"http_tokens": "required"}]})
+
+    assert engine.check_imdsv2_required(tf) == []
+
+
+def test_imdsv1_optional_tokens_is_high(engine):
+    tf = _resources("aws_instance", "web", {"metadata_options": {"http_tokens": "optional"}})
+
+    vulns = engine.check_imdsv2_required(tf)
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.HIGH
+    assert "IMDSv1" in vulns[0].message
+
+
+def test_imdsv1_missing_metadata_block_is_high(engine):
+    tf = _resources("aws_instance", "web", {"ami": "ami-123"})
+
+    vulns = engine.check_imdsv2_required(tf)
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.HIGH
+
+
+def test_imdsv2_handles_empty_metadata_list(engine):
+    tf = _resources("aws_instance", "web", {"metadata_options": []})
+
+    assert len(engine.check_imdsv2_required(tf)) == 1
+
+
+def test_imdsv2_handles_empty_content(engine):
+    assert engine.check_imdsv2_required({}) == []
+
+
+# ---------------------------------------------------------------------------
+# check_public_instance
+# ---------------------------------------------------------------------------
+
+def test_public_instance_is_low(engine):
+    tf = _resources("aws_instance", "web", {"associate_public_ip_address": True})
+
+    vulns = engine.check_public_instance(tf)
+
+    assert len(vulns) == 1
+    assert vulns[0].severity == Severity.LOW
+    assert "public IP" in vulns[0].message
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param({"associate_public_ip_address": False}, id="explicitly_private"),
+        pytest.param({"ami": "ami-123"}, id="attribute_absent"),
+    ],
+)
+def test_private_instance_is_silent(engine, config):
+    assert engine.check_public_instance(_resources("aws_instance", "web", config)) == []
+
+
+def test_public_instance_handles_empty_content(engine):
+    assert engine.check_public_instance({}) == []
+
+
+# ---------------------------------------------------------------------------
+# analyze() wiring — new rules must run as part of the aggregate
+# ---------------------------------------------------------------------------
+
+def test_analyze_includes_new_resource_rules(engine):
+    tf = {
+        "resource": [
+            {"aws_db_instance": [{"db": {"publicly_accessible": True}}]},
+            {"aws_security_group": [{"sg": {"egress": [{"cidr_blocks": ["0.0.0.0/0"]}]}}]},
+            {"aws_instance": [{"web": {"associate_public_ip_address": True}}]},
+        ]
+    }
+
+    messages = " ".join(v.message for v in engine.analyze(tf, ""))
+
+    assert "Publicly accessible RDS" in messages
+    assert "Unrestricted egress" in messages
+    assert "IMDSv1" in messages          # aws_instance has no IMDSv2 enforcement
+    assert "public IP" in messages


### PR DESCRIPTION
## Summary

Production is healthy (`terravault-oguarni.duckdns.org`: HTTP 200, DB connected, Redis rate limiting, OpenAPI live), so this PR closes the highest-leverage gap instead: the **detection engine**. Everything around the scanner (Clean Architecture, CI gate + ratchet, GCP deploy, ML decoupling, monitoring) was already portfolio-grade, but the scanner shipped only **7 rules** — the actual product value. This takes it to **11**, with the same rigor the rest of the repo enforces.

## New rules

| # | Rule | Severity | Detects |
|---|------|----------|---------|
| 8 | `check_public_rds` | CRITICAL | `aws_db_instance` with `publicly_accessible = true` |
| 9 | `check_unrestricted_egress` | LOW | SG egress open to `0.0.0.0/0` / `::/0` (reuses `_open_scopes`) |
| 10 | `check_imdsv2_required` | HIGH | `aws_instance` allowing IMDSv1 (the Capital One SSRF→cred-theft class) |
| 11 | `check_public_instance` | LOW | `aws_instance` auto-assigning a public IP |

Plus a `_truthy()` helper so HCL bools and `.tf.json` string-bools are handled consistently.

## Supporting changes
- **+28 unit tests** (`test_security_rules_resources.py`), full coverage of the new rules.
- Enriched `vulnerable.tf` (now flags all 4 new issues — **12 findings**) and `secure.tf` (stays clean — **0 findings**, demonstrates the secure pattern).
- Fixed one existing test whose "rules see nothing" premise the IMDSv1/public-IP rules invalidated (switched its fixture to a rule-clean `aws_subnet` with `map_public_ip_on_launch`).
- Synced the rule count across README + all four CLAUDE.md docs.
- Bumped the ratchet baseline to lock in the coverage gain.

## Deploy note
Rules-only change — the **8-dim ML feature vector is untouched**, so **no model retrain is needed**. Standard VM update: `git pull && docker compose build terravault-api`.

## Quality gate (mirrors CI) — green

| Check | Result |
|-------|--------|
| pytest | PASS (133 passed, was 105) |
| ratchet | PASS (coverage 74.95% → 76.49%, files=5, dupes=0) |
| pylint | PASS (10.00/10) |
| flake8 | PASS (0) |
| bandit | PASS (0) |
| mypy | PASS (0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)